### PR TITLE
页面滚动之后的位置问题

### DIFF
--- a/src/components/directive.ts
+++ b/src/components/directive.ts
@@ -3,7 +3,7 @@ import { DirectiveBinding } from 'vue'
 const onMounted = (el: HTMLElement, binding: DirectiveBinding) => {
   el.addEventListener('contextmenu', e => {
     e.preventDefault()
-    bus.emit('add-contextmenu', { x: e.pageX, y: e.pageY, value: binding.value })
+    bus.emit('add-contextmenu', { x: e.clientX, y: e.clientY, value: binding.value })
   })
   document.addEventListener('click', () => {
     bus.emit('hide-contextmenu')

--- a/src/components/emitContext.ts
+++ b/src/components/emitContext.ts
@@ -2,6 +2,6 @@ import bus from './bus'
 
 export default function ($event: MouseEvent, value: Record<string, unknown>) {
   $event.preventDefault()
-  bus.emit('add-contextmenu', { x: $event.pageX, y: $event.pageY, value })
+  bus.emit('add-contextmenu', { x: $event.clientX, y: $event.clientY, value })
   document.addEventListener('click', () => { bus.emit('hide-contextmenu') })
 }


### PR DESCRIPTION
页面滚动之后菜单的位置会有问题，菜单的位置应该是相对于客户端(client)的而不是相对于文档(page)的。