### PR TITLE
fix: hideContext方法的调用不需要提供event参数

### DIFF
--- a/src/components/hideContext.ts
+++ b/src/components/hideContext.ts
@@ -1,6 +1,5 @@
 import bus from './bus'
 
-export default function ($event: MouseEvent) {
-  $event.preventDefault()
+export default function () {
   bus.emit('hide-contextmenu')
 }


### PR DESCRIPTION
在业务侧通过hideContext主动关闭菜单时，hideContext方法的执行逻辑实际上并不需要接受任何参数